### PR TITLE
chore: accept any 2.x docusaurus build

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typescript": "4.8.4"
   },
   "dependencies": {
-    "@docusaurus/theme-classic": "2.1.0"
+    "@docusaurus/theme-classic": "^2.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
May help alleviate these [warnings](https://github.com/twitch4j/twitch4j.github.io/actions/runs/3176871707/jobs/5176664864): `warning "@philippheuer/docusaurus-components > @docusaurus/theme-classic > @docusaurus/types@2.0.1" has incorrect peer dependency "react-dom@^16.8.4 || ^17.0.0".`